### PR TITLE
compatibility to spt 3.9.4 (and 3.9.5?)

### DIFF
--- a/Patch.cs
+++ b/Patch.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using EFT.Interactive;
@@ -13,7 +13,7 @@ using EFT.UI.DragAndDrop;
 using HarmonyLib;
 using BepInEx.Configuration;
 using BepInEx;
-using Aki.Reflection.Utils;
+using SPT.Reflection.Utils;
 
 namespace ZeroingQOL
 {


### PR DESCRIPTION
basically nothing to do - but liked the plugin and made it the tiny changes. (I'm still on 3.9.4 since "Questing Bots" is holding me back from 3.9.5, which in combination breaks any bot spawns - but 3.9.4 <-> 3.9.5 _should_ be no problem in this case)